### PR TITLE
Auto-Update Pkgfile version

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,9 +28,6 @@ Split them into 2 categories:
     * add info that PKGMK_ARCH variable exists: **currently I found 85 occurencies of `uname -m` in the official Pkgfiles.
 
 
-### Add for VCS (version control source) code to auomaticaly update the Pkgfile version.
-
-
 ### Unify code style in `pkgmk.in`: backticks to parentheses style
 
 Change all backticks to parentheses style [see](http://mywiki.wooledge.org/BashFAQ/082)
@@ -70,4 +67,6 @@ quoted string -- except $, ` (backquote), and \ (escape).
 
     Currently: When using VCS sources any currently checked out source will not be updated to the latest revision.
 
-* `pkgmk.in` rewrite info *Pkgfile: source (array)* in the documentation and remove it from the `pkgmk.in` file
+* `pkgmk.in` rewrite info *Pkgfile: source (array)* (the big block at the top of the file)
+    in the documentation and remove it from the `pkgmk.in` file
+    

--- a/scripts/pkgmk.in
+++ b/scripts/pkgmk.in
@@ -49,6 +49,7 @@
 #       SVN - function for handling the *extraction* of `Subversion` sources
 #       HG - function for handling the *extraction* of `Mercurial` sources
 #       BZR - function for handling the *extraction* of `Bazaar` sources
+#   PKGFILE VERSION FUNCTIONS
 #   PACKAGE FUNCTIONS
 #       COMPRESSION  - package functions
 #       PACKAGE PACK/REMOVE functions: lib, devel, doc, man, service
@@ -305,6 +306,58 @@ interrupted() {
 have_function() {
 	declare -f "$1" >/dev/null
 }
+
+# first exit all subshells, then print the error
+error_function() {
+	if (( ! BASH_SUBSHELL )); then
+		error "$(gettext "A failure occurred in %s().")" "$1"
+		plain "$(gettext "Aborting...")"
+	fi
+	exit 1
+}
+
+source_safe() {
+	shopt -u extglob
+	if ! source "$@"; then
+		error "$(gettext "Failed to source %s")" "$1"
+		exit 1
+	fi
+	shopt -s extglob
+}
+
+run_function_safe() {
+	local restoretrap
+
+	set -e
+	set -E
+
+	restoretrap=$(trap -p ERR)
+	trap 'error_function $pkgfunc' ERR
+
+	run_function "$1"
+
+	eval $restoretrap
+
+	set +E
+	set +e
+}
+
+run_function() {
+	if [[ -z $1 ]]; then
+		return 1
+	fi
+	local pkgfunc="$1"
+
+	#msg "$(gettext "Starting %s()...")" "$pkgfunc"
+	cd_safe "$SRC"
+
+	# save our shell options so pkgfunc() can't override what we need
+	local shellopts=$(shopt -p)
+    "$pkgfunc"
+	# reset our shell options
+	eval "$shellopts"
+}
+
 
 #**********************************************************************************************************************
 #   GENERAL - helper functions
@@ -1059,10 +1112,57 @@ extract_bzr() {
 
 #**********************************************************************************************************************
 #
-#   PACKAGE FUNCTIONS
+#   PKGFILE VERSION FUNCTIONS
 #
 #**********************************************************************************************************************
 
+# return: full version spec, including version, version
+get_full_version() {
+	printf "%s\n" "$version-$release"
+}
+
+check_version() {
+    local PKG_VERSION="$1"
+	if [[ -z "$PKG_VERSION" ]]; then
+		abort "$(gettext "Package 'version' is not allowed to be empty.")"
+	fi
+	if [[ "$PKG_VERSION" = *[[:space:]:-]:\|]* ]]; then
+		abort "$(gettext "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace.")" "$PKG_VERSION"
+	fi
+}
+
+# Automatically update Pkgfile version variable if a setversion() function is provided
+# Re-sources the PKGBUILD afterwards to allow for other variables that use $version
+update_pkgver() {
+    msg "$(gettext "Updating Pkgfile version variable...")"
+    BUILDFILE="$PKGMK_ROOT/$PKGMK_PKGFILE"
+	NEW_VERSION=$(run_function_safe setversion)
+	if ! check_version "$NEW_VERSION"; then
+		abort "$(gettext "setversion() generated an invalid version: %s")" "$NEW_VERSION"
+	fi
+	if [[ -n $NEW_VERSION && $NEW_VERSION != "$version" ]]; then
+		if [[ -f $BUILDFILE && -w $BUILDFILE ]]; then
+			if ! sed -i "s|^version=[^ ]*|version=$NEW_VERSION     # previous: $version|" "$BUILDFILE"; then
+				abort "$(gettext "Failed to update 'Pkgfile version' from: <%s> to <%s>")" "$version" "$NEW_VERSION"
+			fi
+			sed -i "s:|^pkgrel=[^ ]*|pkgrel=1|" "$BUILDFILE"
+            
+            # TODO: Decide if we should keep that or just update the version variable with the new one.
+			source_safe "$BUILDFILE"
+			msg2 "$(gettext "Updated 'Pkgfile version' from: <%s> to <%s>")" "$version" "$NEW_VERSION"
+            msg2 "$(gettext "Full version is now: <%s>")" "$(get_full_version)"
+		else
+			warning "$(gettext "<%s> is not writeable -- version will not be updated")" "$BUILDFILE"
+		fi
+	fi
+}
+
+
+#**********************************************************************************************************************
+#
+#   PACKAGE FUNCTIONS
+#
+#**********************************************************************************************************************
 
 #**********************************************************************************************************************
 #   COMPRESSION  - package functions
@@ -1295,7 +1395,9 @@ check_pkgfile() {
 	fi
 	if [ "${version}" == "" ]; then
         abort "$(gettext "Variable 'version' not initiated or not found in <%s>")" "$PKGMK_PKGFILE"
-	fi
+    else
+        check_version "$version"
+    fi
 	if [ "${release}" == "" ]; then
         abort "$(gettext "Variable 'release' not initiated or not found in<%s>")" "$PKGMK_PKGFILE"
 	fi
@@ -1655,7 +1757,13 @@ build_package() {
 
 	extract_source
 
-	cd $SRC
+	cd "$SRC"
+    
+    if have_function 'setversion'; then
+        # Update Pkgfile with new version variable
+        update_pkgver
+	fi
+    
     if have_function 'prepare'; then
 		(set -e -x ; prepare)
 	fi
@@ -2402,7 +2510,7 @@ PKGMK_PKGFILE="Pkgfile"
 PKGMK_INSTALL="no"
 PKGMK_RECURSIVE="no"
 PKGMK_UPDATE_MD5SUM="no"
-PKGMK_CHECK_MD5SUM="no"  # TODO: Remove this later
+PKGMK_CHECK_MD5SUM="no"
 PKGMK_SPIT="no"
 
 

--- a/scripts/po/de_DE.UTF-8/LC_MESSAGES/pkgmk_empty.po
+++ b/scripts/po/de_DE.UTF-8/LC_MESSAGES/pkgmk_empty.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cards\n"
 "Report-Msgid-Bugs-To: https://github.com/NuTyX/cards/issues\n"
-"POT-Creation-Date: 2016-03-01 13:16-0500\n"
-"PO-Revision-Date: 2016-03-01 13:16-0500\n"
+"POT-Creation-Date: 2016-03-01 16:18-0500\n"
+"PO-Revision-Date: 2016-03-01 16:18-0500\n"
 "Last-Translator: NuTyX Team <https://github.com/NuTyX/cards>\n"
 "Language-Team: LANGUAGE <https://github.com/NuTyX/cards>\n"
 "Language: de\n"
@@ -17,442 +17,486 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: pkgmk.in:242
+#: pkgmk.in:243
 msgid "WARNING:"
 msgstr ""
 
-#: pkgmk.in:247 pkgmk.in:280 pkgmk.in:290
+#: pkgmk.in:248 pkgmk.in:281 pkgmk.in:291
 msgid "ERROR:"
 msgstr ""
 
-#: pkgmk.in:260 pkgmk.in:268 pkgmk.in:281
+#: pkgmk.in:261 pkgmk.in:269 pkgmk.in:282
 msgid "ABORTING....\\n"
 msgstr ""
 
-#: pkgmk.in:279
+#: pkgmk.in:280
 msgid "Building failed: <%s>"
 msgstr ""
 
-#: pkgmk.in:351
+#: pkgmk.in:313
+msgid "A failure occurred in %s()."
+msgstr ""
+
+#: pkgmk.in:314
+msgid "Aborting..."
+msgstr ""
+
+#: pkgmk.in:322
+msgid "Failed to source %s"
+msgstr ""
+
+#: pkgmk.in:404
 msgid "Directory <%s> does not exist."
 msgstr ""
 
-#: pkgmk.in:353
+#: pkgmk.in:406
 msgid "Directory <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:355
+#: pkgmk.in:408
 msgid "Directory <%s> is not readable."
 msgstr ""
 
-#: pkgmk.in:361
+#: pkgmk.in:414
 msgid "File <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:475
+#: pkgmk.in:528
 msgid "Removing source <%s>"
 msgstr ""
 
-#: pkgmk.in:543
+#: pkgmk.in:596
 msgid "Downloading file URL: <%s>"
 msgstr ""
 
-#: pkgmk.in:546
+#: pkgmk.in:599
 msgid "Command <%s> not found."
 msgstr ""
 
-#: pkgmk.in:577
+#: pkgmk.in:630
 msgid "Partial download found, trying to resume..."
 msgstr ""
 
-#: pkgmk.in:596
+#: pkgmk.in:649
 msgid "Partial download failed, restarting download..."
 msgstr ""
 
-#: pkgmk.in:625
+#: pkgmk.in:678
 msgid "Downloading git into: <%s>"
 msgstr ""
 
-#: pkgmk.in:631
+#: pkgmk.in:684
 msgid "Cloning git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:641
+#: pkgmk.in:694
 msgid "Updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:644
+#: pkgmk.in:697
 msgid "Failure while updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:668
+#: pkgmk.in:721
 msgid "Downloading svn into: <%s>"
 msgstr ""
 
-#: pkgmk.in:687
+#: pkgmk.in:740
 msgid "Cloning svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:694
+#: pkgmk.in:747
 msgid "Updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:698
+#: pkgmk.in:751
 msgid "Failure while updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:717
+#: pkgmk.in:770
 msgid "Downloading hg into: <%s>"
 msgstr ""
 
-#: pkgmk.in:723
+#: pkgmk.in:776
 msgid "Cloning hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:728
+#: pkgmk.in:781
 msgid "Updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:732
+#: pkgmk.in:785
 msgid "Failure while updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:755
+#: pkgmk.in:808
 msgid "Downloading bzr into: <%s>"
 msgstr ""
 
-#: pkgmk.in:758
+#: pkgmk.in:811
 msgid "Branching bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:763
+#: pkgmk.in:816
 msgid "Pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:767
+#: pkgmk.in:820
 msgid "Failure while pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:871
+#: pkgmk.in:924
 msgid "Extracting file with (%s): <%s>"
 msgstr ""
 
-#: pkgmk.in:908
+#: pkgmk.in:961
 msgid "Creating working copy of git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:962
+#: pkgmk.in:1015
 msgid "Creating working copy of svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:990
+#: pkgmk.in:1043
 msgid "Creating working copy of hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1044
+#: pkgmk.in:1097
 msgid "Creating working copy of bzr repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1072
+#: pkgmk.in:1127
+msgid "Package 'version' is not allowed to be empty."
+msgstr ""
+
+#: pkgmk.in:1130
+msgid "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace."
+msgstr ""
+
+#: pkgmk.in:1137
+msgid "Updating Pkgfile version variable..."
+msgstr ""
+
+#: pkgmk.in:1141
+msgid "setversion() generated an invalid version: %s"
+msgstr ""
+
+#: pkgmk.in:1146
+msgid "Failed to update 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1152
+msgid "Updated 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1153
+msgid "Full version is now: <%s>"
+msgstr ""
+
+#: pkgmk.in:1155
+msgid "<%s> is not writeable -- version will not be updated"
+msgstr ""
+
+#: pkgmk.in:1172
 msgid "Using (%s) to compress <%s>"
 msgstr ""
 
-#: pkgmk.in:1284
+#: pkgmk.in:1384
 msgid "Variable 'name' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1287
+#: pkgmk.in:1387
 msgid "Function 'build' not specified in <%s>"
 msgstr ""
 
-#: pkgmk.in:1291
+#: pkgmk.in:1391
 msgid "Variable 'name' contains following illegal characters: <%s>"
 msgstr ""
 
-#: pkgmk.in:1294
+#: pkgmk.in:1394
 msgid "Variable 'name' length higher then 50 characters."
 msgstr ""
 
-#: pkgmk.in:1297 pkgmk.in:2108 pkgmk.in:2111
+#: pkgmk.in:1397 pkgmk.in:2216 pkgmk.in:2219
 msgid "Variable 'version' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1300
+#: pkgmk.in:1402
 msgid "Variable 'release' not initiated or not found in<%s>"
 msgstr ""
 
-#: pkgmk.in:1304
+#: pkgmk.in:1406
 msgid "Variable 'release' contains following illegal characters:<%s>"
 msgstr ""
 
-#: pkgmk.in:1307
+#: pkgmk.in:1409
 msgid "Variable 'release' outside limit which is '99999999'."
 msgstr ""
 
-#: pkgmk.in:1310
+#: pkgmk.in:1412
 msgid "Variable 'description' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1314
+#: pkgmk.in:1416
 msgid "Variable 'description' length higher then 110 characters, please resize to 110 char ]"
 msgstr ""
 
-#: pkgmk.in:1315
+#: pkgmk.in:1417
 msgid "%s <== <%s> characters"
 msgstr ""
 
-#: pkgmk.in:1412
+#: pkgmk.in:1514
 msgid "Md5sum mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1420
+#: pkgmk.in:1522
 msgid "Md5sum not ok."
 msgstr ""
 
-#: pkgmk.in:1422 pkgmk.in:1684 pkgmk.in:1695 pkgmk.in:1701 pkgmk.in:1770
+#: pkgmk.in:1524 pkgmk.in:1792 pkgmk.in:1803 pkgmk.in:1809 pkgmk.in:1878
 msgid "Building <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1429
+#: pkgmk.in:1531
 msgid "Md5sum not found."
 msgstr ""
 
-#: pkgmk.in:1432
+#: pkgmk.in:1534
 msgid "Md5sum not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1440
+#: pkgmk.in:1542
 msgid "Md5sum ok."
 msgstr ""
 
-#: pkgmk.in:1477
+#: pkgmk.in:1579
 msgid "Unable to update footprint"
 msgstr ""
 
-#: pkgmk.in:1495 pkgmk.in:1497
+#: pkgmk.in:1597 pkgmk.in:1599
 msgid "Footprint mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1503
+#: pkgmk.in:1605
 msgid "Footprint not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1507
+#: pkgmk.in:1609
 msgid "Package <%s> was not found."
 msgstr ""
 
-#: pkgmk.in:1558
+#: pkgmk.in:1660
 msgid "Adding meta data to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1595 pkgmk.in:1606
+#: pkgmk.in:1697 pkgmk.in:1708
 msgid "Adding runtime deps to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1598 pkgmk.in:1609
+#: pkgmk.in:1700 pkgmk.in:1711
 msgid "Runtime dependency <%s> not found, cannot continue."
 msgstr ""
 
-#: pkgmk.in:1641
+#: pkgmk.in:1743
 msgid "<%s> should be removed."
 msgstr ""
 
-#: pkgmk.in:1643
+#: pkgmk.in:1745
 msgid "Remove the binaries first..."
 msgstr ""
 
-#: pkgmk.in:1651
+#: pkgmk.in:1753
 msgid "Packages should be built as root."
 msgstr ""
 
-#: pkgmk.in:1654
+#: pkgmk.in:1756
 msgid "Building package: <%s>"
 msgstr ""
 
-#: pkgmk.in:1737
+#: pkgmk.in:1845
 msgid "No files found in package <%s>"
 msgstr ""
 
-#: pkgmk.in:1742
+#: pkgmk.in:1850
 msgid "Footprint ignored."
 msgstr ""
 
-#: pkgmk.in:1753
+#: pkgmk.in:1861
 msgid "Package(s) not found(s)..."
 msgstr ""
 
-#: pkgmk.in:1778
+#: pkgmk.in:1886
 msgid "Package(s) not found(s) nothing to install..."
 msgstr ""
 
-#: pkgmk.in:1782
+#: pkgmk.in:1890
 msgid "Installing <%s>"
 msgstr ""
 
-#: pkgmk.in:1795
+#: pkgmk.in:1903
 msgid "Installing <%s> succeeded."
 msgstr ""
 
-#: pkgmk.in:1797
+#: pkgmk.in:1905
 msgid "Installing <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1812
+#: pkgmk.in:1920
 msgid "Entering directory  <%s>"
 msgstr ""
 
-#: pkgmk.in:1814
+#: pkgmk.in:1922
 msgid "Leaving directory <%s>"
 msgstr ""
 
-#: pkgmk.in:1825 pkgmk.in:1940
+#: pkgmk.in:1933 pkgmk.in:2048
 msgid "Removing <%s>"
 msgstr ""
 
-#: pkgmk.in:1830
+#: pkgmk.in:1938
 msgid "<%s> not found."
 msgstr ""
 
-#: pkgmk.in:1842
+#: pkgmk.in:1950
 msgid "Package(s) not found(s), unable to update footprint."
 msgstr ""
 
-#: pkgmk.in:1847
+#: pkgmk.in:1955
 msgid "Unable to update footprint. File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:1854
+#: pkgmk.in:1962
 msgid "Footprint updated for <%s>"
 msgstr ""
 
-#: pkgmk.in:1944
+#: pkgmk.in:2052
 msgid "Removing MD5SUM."
 msgstr ""
 
-#: pkgmk.in:2059 pkgmk.in:2078
+#: pkgmk.in:2167 pkgmk.in:2186
 msgid "File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:2064
+#: pkgmk.in:2172
 msgid "Command <pkginfo> NOT FOUND, footprint ignored."
 msgstr ""
 
-#: pkgmk.in:2118
+#: pkgmk.in:2226
 msgid "Configuration settings..."
 msgstr ""
 
-#: pkgmk.in:2119
+#: pkgmk.in:2227
 msgid "PKGMK_INSTALL:          %s"
 msgstr ""
 
-#: pkgmk.in:2120
+#: pkgmk.in:2228
 msgid "PKGMK_WORK_DIR:         %s"
 msgstr ""
 
-#: pkgmk.in:2121
+#: pkgmk.in:2229
 msgid "PKGMK_SOURCE_DIR:       %s"
 msgstr ""
 
-#: pkgmk.in:2125
+#: pkgmk.in:2233
 msgid "CLEAN IGNORED."
 msgstr ""
 
-#: pkgmk.in:2127
+#: pkgmk.in:2235
 msgid "PKGMK_KEEP_SOURCES:     %s"
 msgstr ""
 
-#: pkgmk.in:2128
+#: pkgmk.in:2236
 msgid "PKGMK_CLEAN:            %s"
 msgstr ""
 
-#: pkgmk.in:2133
+#: pkgmk.in:2241
 msgid "FOOTPRINT AND MD5SUM IGNORED."
 msgstr ""
 
-#: pkgmk.in:2136
+#: pkgmk.in:2244
 msgid "PKGMK_IGNORE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2138
+#: pkgmk.in:2246
 msgid "PKGMK_UPDATE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2140
+#: pkgmk.in:2248
 msgid "PKGMK_IGNORE_FOOTPRINT: %s"
 msgstr ""
 
-#: pkgmk.in:2141
+#: pkgmk.in:2249
 msgid "PKGMK_IGNORE_MD5SUM:    %s"
 msgstr ""
 
-#: pkgmk.in:2144
+#: pkgmk.in:2252
 msgid "<%s> file will be deleted."
 msgstr ""
 
-#: pkgmk.in:2147
+#: pkgmk.in:2255
 msgid "PKGMK_COMPRESS_PACKAGE: %s"
 msgstr ""
 
-#: pkgmk.in:2149
+#: pkgmk.in:2257
 msgid "PKGMK_COMPRESSION_MODE: %s"
 msgstr ""
 
-#: pkgmk.in:2151
+#: pkgmk.in:2259
 msgid "PKGMK_COMPRESSION_OPTS: %s"
 msgstr ""
 
-#: pkgmk.in:2155
+#: pkgmk.in:2263
 msgid "Package info..."
 msgstr ""
 
-#: pkgmk.in:2156
+#: pkgmk.in:2264
 msgid "name:    %s"
 msgstr ""
 
-#: pkgmk.in:2158
+#: pkgmk.in:2266
 msgid "version: %s"
 msgstr ""
 
-#: pkgmk.in:2161
+#: pkgmk.in:2269
 msgid "release: %s"
 msgstr ""
 
-#: pkgmk.in:2164
+#: pkgmk.in:2272
 msgid "group:   %s"
 msgstr ""
 
-#: pkgmk.in:2182
+#: pkgmk.in:2290
 msgid "Compression mode <%s> not supported."
 msgstr ""
 
-#: pkgmk.in:2210
+#: pkgmk.in:2318
 msgid "description: <%s>"
 msgstr ""
 
-#: pkgmk.in:2211
+#: pkgmk.in:2319
 msgid "url: <%s>"
 msgstr ""
 
-#: pkgmk.in:2212
+#: pkgmk.in:2320
 msgid "packager: <%s>"
 msgstr ""
 
-#: pkgmk.in:2213
+#: pkgmk.in:2321
 msgid "maintainer: <%s>"
 msgstr ""
 
-#: pkgmk.in:2221
+#: pkgmk.in:2329
 msgid "Md5sum updated."
 msgstr ""
 
-#: pkgmk.in:2233
+#: pkgmk.in:2341
 msgid "Extracting sources of package <%s>"
 msgstr ""
 
-#: pkgmk.in:2243 pkgmk.in:2250
+#: pkgmk.in:2351 pkgmk.in:2358
 msgid "Package <%s> is not up to date."
 msgstr ""
 
-#: pkgmk.in:2245 pkgmk.in:2252 pkgmk.in:2262 pkgmk.in:2274
+#: pkgmk.in:2353 pkgmk.in:2360 pkgmk.in:2370 pkgmk.in:2382
 msgid "Package <%s> is up to date."
 msgstr ""

--- a/scripts/po/en_US.UTF-8/LC_MESSAGES/pkgmk_empty.po
+++ b/scripts/po/en_US.UTF-8/LC_MESSAGES/pkgmk_empty.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cards\n"
 "Report-Msgid-Bugs-To: https://github.com/NuTyX/cards/issues\n"
-"POT-Creation-Date: 2016-03-01 13:16-0500\n"
-"PO-Revision-Date: 2016-03-01 13:16-0500\n"
+"POT-Creation-Date: 2016-03-01 16:18-0500\n"
+"PO-Revision-Date: 2016-03-01 16:18-0500\n"
 "Last-Translator: NuTyX Team <https://github.com/NuTyX/cards>\n"
 "Language-Team: LANGUAGE <https://github.com/NuTyX/cards>\n"
 "Language: en_US\n"
@@ -17,442 +17,486 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: pkgmk.in:242
+#: pkgmk.in:243
 msgid "WARNING:"
 msgstr "WARNING:"
 
-#: pkgmk.in:247 pkgmk.in:280 pkgmk.in:290
+#: pkgmk.in:248 pkgmk.in:281 pkgmk.in:291
 msgid "ERROR:"
 msgstr "ERROR:"
 
-#: pkgmk.in:260 pkgmk.in:268 pkgmk.in:281
+#: pkgmk.in:261 pkgmk.in:269 pkgmk.in:282
 msgid "ABORTING....\\n"
 msgstr "ABORTING....\\n"
 
-#: pkgmk.in:279
+#: pkgmk.in:280
 msgid "Building failed: <%s>"
 msgstr "Building failed: <%s>"
 
-#: pkgmk.in:351
+#: pkgmk.in:313
+msgid "A failure occurred in %s()."
+msgstr "A failure occurred in %s()."
+
+#: pkgmk.in:314
+msgid "Aborting..."
+msgstr "Aborting..."
+
+#: pkgmk.in:322
+msgid "Failed to source %s"
+msgstr "Failed to source %s"
+
+#: pkgmk.in:404
 msgid "Directory <%s> does not exist."
 msgstr "Directory <%s> does not exist."
 
-#: pkgmk.in:353
+#: pkgmk.in:406
 msgid "Directory <%s> is not writable."
 msgstr "Directory <%s> is not writable."
 
-#: pkgmk.in:355
+#: pkgmk.in:408
 msgid "Directory <%s> is not readable."
 msgstr "Directory <%s> is not readable."
 
-#: pkgmk.in:361
+#: pkgmk.in:414
 msgid "File <%s> is not writable."
 msgstr "File <%s> is not writable."
 
-#: pkgmk.in:475
+#: pkgmk.in:528
 msgid "Removing source <%s>"
 msgstr "Removing source <%s>"
 
-#: pkgmk.in:543
+#: pkgmk.in:596
 msgid "Downloading file URL: <%s>"
 msgstr "Downloading file URL: <%s>"
 
-#: pkgmk.in:546
+#: pkgmk.in:599
 msgid "Command <%s> not found."
 msgstr "Command <%s> not found."
 
-#: pkgmk.in:577
+#: pkgmk.in:630
 msgid "Partial download found, trying to resume..."
 msgstr "Partial download found, trying to resume..."
 
-#: pkgmk.in:596
+#: pkgmk.in:649
 msgid "Partial download failed, restarting download..."
 msgstr "Partial download failed, restarting download..."
 
-#: pkgmk.in:625
+#: pkgmk.in:678
 msgid "Downloading git into: <%s>"
 msgstr "Downloading git into: <%s>"
 
-#: pkgmk.in:631
+#: pkgmk.in:684
 msgid "Cloning git repo <%s>"
 msgstr "Cloning git repo <%s>"
 
-#: pkgmk.in:641
+#: pkgmk.in:694
 msgid "Updating git repo <%s>"
 msgstr "Updating git repo <%s>"
 
-#: pkgmk.in:644
+#: pkgmk.in:697
 msgid "Failure while updating git repo <%s>"
 msgstr "Failure while updating git repo <%s>"
 
-#: pkgmk.in:668
+#: pkgmk.in:721
 msgid "Downloading svn into: <%s>"
 msgstr "Downloading svn into: <%s>"
 
-#: pkgmk.in:687
+#: pkgmk.in:740
 msgid "Cloning svn repo <%s>"
 msgstr "Cloning svn repo <%s>"
 
-#: pkgmk.in:694
+#: pkgmk.in:747
 msgid "Updating svn repo <%s>"
 msgstr "Updating svn repo <%s>"
 
-#: pkgmk.in:698
+#: pkgmk.in:751
 msgid "Failure while updating svn repo <%s>"
 msgstr "Failure while updating svn repo <%s>"
 
-#: pkgmk.in:717
+#: pkgmk.in:770
 msgid "Downloading hg into: <%s>"
 msgstr "Downloading hg into: <%s>"
 
-#: pkgmk.in:723
+#: pkgmk.in:776
 msgid "Cloning hg repo <%s>"
 msgstr "Cloning hg repo <%s>"
 
-#: pkgmk.in:728
+#: pkgmk.in:781
 msgid "Updating hg repo <%s>"
 msgstr "Updating hg repo <%s>"
 
-#: pkgmk.in:732
+#: pkgmk.in:785
 msgid "Failure while updating hg repo <%s>"
 msgstr "Failure while updating hg repo <%s>"
 
-#: pkgmk.in:755
+#: pkgmk.in:808
 msgid "Downloading bzr into: <%s>"
 msgstr "Downloading bzr into: <%s>"
 
-#: pkgmk.in:758
+#: pkgmk.in:811
 msgid "Branching bzr displaylocation <%s>"
 msgstr "Branching bzr displaylocation <%s>"
 
-#: pkgmk.in:763
+#: pkgmk.in:816
 msgid "Pulling bzr displaylocation <%s>"
 msgstr "Pulling bzr displaylocation <%s>"
 
-#: pkgmk.in:767
+#: pkgmk.in:820
 msgid "Failure while pulling bzr displaylocation <%s>"
 msgstr "Failure while pulling bzr displaylocation <%s>"
 
-#: pkgmk.in:871
+#: pkgmk.in:924
 msgid "Extracting file with (%s): <%s>"
 msgstr "Extracting file with (%s): <%s>"
 
-#: pkgmk.in:908
+#: pkgmk.in:961
 msgid "Creating working copy of git repo <%s>"
 msgstr "Creating working copy of git repo <%s>"
 
-#: pkgmk.in:962
+#: pkgmk.in:1015
 msgid "Creating working copy of svn repo <%s>"
 msgstr "Creating working copy of svn repo <%s>"
 
-#: pkgmk.in:990
+#: pkgmk.in:1043
 msgid "Creating working copy of hg repo <%s>"
 msgstr "Creating working copy of hg repo <%s>"
 
-#: pkgmk.in:1044
+#: pkgmk.in:1097
 msgid "Creating working copy of bzr repo <%s>"
 msgstr "Creating working copy of bzr repo <%s>"
 
-#: pkgmk.in:1072
+#: pkgmk.in:1127
+msgid "Package 'version' is not allowed to be empty."
+msgstr "Package 'version' is not allowed to be empty."
+
+#: pkgmk.in:1130
+msgid "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace."
+msgstr "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace."
+
+#: pkgmk.in:1137
+msgid "Updating Pkgfile version variable..."
+msgstr "Updating Pkgfile version variable..."
+
+#: pkgmk.in:1141
+msgid "setversion() generated an invalid version: %s"
+msgstr "setversion() generated an invalid version: %s"
+
+#: pkgmk.in:1146
+msgid "Failed to update 'Pkgfile version' from: <%s> to <%s>"
+msgstr "Failed to update 'Pkgfile version' from: <%s> to <%s>"
+
+#: pkgmk.in:1152
+msgid "Updated 'Pkgfile version' from: <%s> to <%s>"
+msgstr "Updated 'Pkgfile version' from: <%s> to <%s>"
+
+#: pkgmk.in:1153
+msgid "Full version is now: <%s>"
+msgstr "Full version is now: <%s>"
+
+#: pkgmk.in:1155
+msgid "<%s> is not writeable -- version will not be updated"
+msgstr "<%s> is not writeable -- version will not be updated"
+
+#: pkgmk.in:1172
 msgid "Using (%s) to compress <%s>"
 msgstr "Using (%s) to compress <%s>"
 
-#: pkgmk.in:1284
+#: pkgmk.in:1384
 msgid "Variable 'name' not initiated or not found in <%s>"
 msgstr "Variable 'name' not initiated or not found in <%s>"
 
-#: pkgmk.in:1287
+#: pkgmk.in:1387
 msgid "Function 'build' not specified in <%s>"
 msgstr "Function 'build' not specified in <%s>"
 
-#: pkgmk.in:1291
+#: pkgmk.in:1391
 msgid "Variable 'name' contains following illegal characters: <%s>"
 msgstr "Variable 'name' contains following illegal characters: <%s>"
 
-#: pkgmk.in:1294
+#: pkgmk.in:1394
 msgid "Variable 'name' length higher then 50 characters."
 msgstr "Variable 'name' length higher then 50 characters."
 
-#: pkgmk.in:1297 pkgmk.in:2108 pkgmk.in:2111
+#: pkgmk.in:1397 pkgmk.in:2216 pkgmk.in:2219
 msgid "Variable 'version' not initiated or not found in <%s>"
 msgstr "Variable 'version' not initiated or not found in <%s>"
 
-#: pkgmk.in:1300
+#: pkgmk.in:1402
 msgid "Variable 'release' not initiated or not found in<%s>"
 msgstr "Variable 'release' not initiated or not found in<%s>"
 
-#: pkgmk.in:1304
+#: pkgmk.in:1406
 msgid "Variable 'release' contains following illegal characters:<%s>"
 msgstr "Variable 'release' contains following illegal characters:<%s>"
 
-#: pkgmk.in:1307
+#: pkgmk.in:1409
 msgid "Variable 'release' outside limit which is '99999999'."
 msgstr "Variable 'release' outside limit which is '99999999'."
 
-#: pkgmk.in:1310
+#: pkgmk.in:1412
 msgid "Variable 'description' not initiated or not found in <%s>"
 msgstr "Variable 'description' not initiated or not found in <%s>"
 
-#: pkgmk.in:1314
+#: pkgmk.in:1416
 msgid "Variable 'description' length higher then 110 characters, please resize to 110 char ]"
 msgstr "Variable 'description' length higher then 110 characters, please resize to 110 char ]"
 
-#: pkgmk.in:1315
+#: pkgmk.in:1417
 msgid "%s <== <%s> characters"
 msgstr "%s <== <%s> characters"
 
-#: pkgmk.in:1412
+#: pkgmk.in:1514
 msgid "Md5sum mismatch found:"
 msgstr "Md5sum mismatch found:"
 
-#: pkgmk.in:1420
+#: pkgmk.in:1522
 msgid "Md5sum not ok."
 msgstr "Md5sum not ok."
 
-#: pkgmk.in:1422 pkgmk.in:1684 pkgmk.in:1695 pkgmk.in:1701 pkgmk.in:1770
+#: pkgmk.in:1524 pkgmk.in:1792 pkgmk.in:1803 pkgmk.in:1809 pkgmk.in:1878
 msgid "Building <%s> failed."
 msgstr "Building <%s> failed."
 
-#: pkgmk.in:1429
+#: pkgmk.in:1531
 msgid "Md5sum not found."
 msgstr "Md5sum not found."
 
-#: pkgmk.in:1432
+#: pkgmk.in:1534
 msgid "Md5sum not found, creating new."
 msgstr "Md5sum not found, creating new."
 
-#: pkgmk.in:1440
+#: pkgmk.in:1542
 msgid "Md5sum ok."
 msgstr "Md5sum ok."
 
-#: pkgmk.in:1477
+#: pkgmk.in:1579
 msgid "Unable to update footprint"
 msgstr "Unable to update footprint"
 
-#: pkgmk.in:1495 pkgmk.in:1497
+#: pkgmk.in:1597 pkgmk.in:1599
 msgid "Footprint mismatch found:"
 msgstr "Footprint mismatch found:"
 
-#: pkgmk.in:1503
+#: pkgmk.in:1605
 msgid "Footprint not found, creating new."
 msgstr "Footprint not found, creating new."
 
-#: pkgmk.in:1507
+#: pkgmk.in:1609
 msgid "Package <%s> was not found."
 msgstr "Package <%s> was not found."
 
-#: pkgmk.in:1558
+#: pkgmk.in:1660
 msgid "Adding meta data to Archive <%s>"
 msgstr "Adding meta data to Archive <%s>"
 
-#: pkgmk.in:1595 pkgmk.in:1606
+#: pkgmk.in:1697 pkgmk.in:1708
 msgid "Adding runtime deps to Archive <%s>"
 msgstr "Adding runtime deps to Archive <%s>"
 
-#: pkgmk.in:1598 pkgmk.in:1609
+#: pkgmk.in:1700 pkgmk.in:1711
 msgid "Runtime dependency <%s> not found, cannot continue."
 msgstr "Runtime dependency <%s> not found, cannot continue."
 
-#: pkgmk.in:1641
+#: pkgmk.in:1743
 msgid "<%s> should be removed."
 msgstr "<%s> should be removed."
 
-#: pkgmk.in:1643
+#: pkgmk.in:1745
 msgid "Remove the binaries first..."
 msgstr "Remove the binaries first..."
 
-#: pkgmk.in:1651
+#: pkgmk.in:1753
 msgid "Packages should be built as root."
 msgstr "Packages should be built as root."
 
-#: pkgmk.in:1654
+#: pkgmk.in:1756
 msgid "Building package: <%s>"
 msgstr "Building package: <%s>"
 
-#: pkgmk.in:1737
+#: pkgmk.in:1845
 msgid "No files found in package <%s>"
 msgstr "No files found in package <%s>"
 
-#: pkgmk.in:1742
+#: pkgmk.in:1850
 msgid "Footprint ignored."
 msgstr "Footprint ignored."
 
-#: pkgmk.in:1753
+#: pkgmk.in:1861
 msgid "Package(s) not found(s)..."
 msgstr "Package(s) not found(s)..."
 
-#: pkgmk.in:1778
+#: pkgmk.in:1886
 msgid "Package(s) not found(s) nothing to install..."
 msgstr "Package(s) not found(s) nothing to install..."
 
-#: pkgmk.in:1782
+#: pkgmk.in:1890
 msgid "Installing <%s>"
 msgstr "Installing <%s>"
 
-#: pkgmk.in:1795
+#: pkgmk.in:1903
 msgid "Installing <%s> succeeded."
 msgstr "Installing <%s> succeeded."
 
-#: pkgmk.in:1797
+#: pkgmk.in:1905
 msgid "Installing <%s> failed."
 msgstr "Installing <%s> failed."
 
-#: pkgmk.in:1812
+#: pkgmk.in:1920
 msgid "Entering directory  <%s>"
 msgstr "Entering directory  <%s>"
 
-#: pkgmk.in:1814
+#: pkgmk.in:1922
 msgid "Leaving directory <%s>"
 msgstr "Leaving directory <%s>"
 
-#: pkgmk.in:1825 pkgmk.in:1940
+#: pkgmk.in:1933 pkgmk.in:2048
 msgid "Removing <%s>"
 msgstr "Removing <%s>"
 
-#: pkgmk.in:1830
+#: pkgmk.in:1938
 msgid "<%s> not found."
 msgstr "<%s> not found."
 
-#: pkgmk.in:1842
+#: pkgmk.in:1950
 msgid "Package(s) not found(s), unable to update footprint."
 msgstr "Package(s) not found(s), unable to update footprint."
 
-#: pkgmk.in:1847
+#: pkgmk.in:1955
 msgid "Unable to update footprint. File <%s> not found."
 msgstr "Unable to update footprint. File <%s> not found."
 
-#: pkgmk.in:1854
+#: pkgmk.in:1962
 msgid "Footprint updated for <%s>"
 msgstr "Footprint updated for <%s>"
 
-#: pkgmk.in:1944
+#: pkgmk.in:2052
 msgid "Removing MD5SUM."
 msgstr "Removing MD5SUM."
 
-#: pkgmk.in:2059 pkgmk.in:2078
+#: pkgmk.in:2167 pkgmk.in:2186
 msgid "File <%s> not found."
 msgstr "File <%s> not found."
 
-#: pkgmk.in:2064
+#: pkgmk.in:2172
 msgid "Command <pkginfo> NOT FOUND, footprint ignored."
 msgstr "Command <pkginfo> NOT FOUND, footprint ignored."
 
-#: pkgmk.in:2118
+#: pkgmk.in:2226
 msgid "Configuration settings..."
 msgstr "Configuration settings..."
 
-#: pkgmk.in:2119
+#: pkgmk.in:2227
 msgid "PKGMK_INSTALL:          %s"
 msgstr "PKGMK_INSTALL:          %s"
 
-#: pkgmk.in:2120
+#: pkgmk.in:2228
 msgid "PKGMK_WORK_DIR:         %s"
 msgstr "PKGMK_WORK_DIR:         %s"
 
-#: pkgmk.in:2121
+#: pkgmk.in:2229
 msgid "PKGMK_SOURCE_DIR:       %s"
 msgstr "PKGMK_SOURCE_DIR:       %s"
 
-#: pkgmk.in:2125
+#: pkgmk.in:2233
 msgid "CLEAN IGNORED."
 msgstr "CLEAN IGNORED."
 
-#: pkgmk.in:2127
+#: pkgmk.in:2235
 msgid "PKGMK_KEEP_SOURCES:     %s"
 msgstr "PKGMK_KEEP_SOURCES:     %s"
 
-#: pkgmk.in:2128
+#: pkgmk.in:2236
 msgid "PKGMK_CLEAN:            %s"
 msgstr "PKGMK_CLEAN:            %s"
 
-#: pkgmk.in:2133
+#: pkgmk.in:2241
 msgid "FOOTPRINT AND MD5SUM IGNORED."
 msgstr "FOOTPRINT AND MD5SUM IGNORED."
 
-#: pkgmk.in:2136
+#: pkgmk.in:2244
 msgid "PKGMK_IGNORE_REPO:      %s"
 msgstr "PKGMK_IGNORE_REPO:      %s"
 
-#: pkgmk.in:2138
+#: pkgmk.in:2246
 msgid "PKGMK_UPDATE_REPO:      %s"
 msgstr "PKGMK_UPDATE_REPO:      %s"
 
-#: pkgmk.in:2140
+#: pkgmk.in:2248
 msgid "PKGMK_IGNORE_FOOTPRINT: %s"
 msgstr "PKGMK_IGNORE_FOOTPRINT: %s"
 
-#: pkgmk.in:2141
+#: pkgmk.in:2249
 msgid "PKGMK_IGNORE_MD5SUM:    %s"
 msgstr "PKGMK_IGNORE_MD5SUM:    %s"
 
-#: pkgmk.in:2144
+#: pkgmk.in:2252
 msgid "<%s> file will be deleted."
 msgstr "<%s> file will be deleted."
 
-#: pkgmk.in:2147
+#: pkgmk.in:2255
 msgid "PKGMK_COMPRESS_PACKAGE: %s"
 msgstr "PKGMK_COMPRESS_PACKAGE: %s"
 
-#: pkgmk.in:2149
+#: pkgmk.in:2257
 msgid "PKGMK_COMPRESSION_MODE: %s"
 msgstr "PKGMK_COMPRESSION_MODE: %s"
 
-#: pkgmk.in:2151
+#: pkgmk.in:2259
 msgid "PKGMK_COMPRESSION_OPTS: %s"
 msgstr "PKGMK_COMPRESSION_OPTS: %s"
 
-#: pkgmk.in:2155
+#: pkgmk.in:2263
 msgid "Package info..."
 msgstr "Package info..."
 
-#: pkgmk.in:2156
+#: pkgmk.in:2264
 msgid "name:    %s"
 msgstr "name:    %s"
 
-#: pkgmk.in:2158
+#: pkgmk.in:2266
 msgid "version: %s"
 msgstr "version: %s"
 
-#: pkgmk.in:2161
+#: pkgmk.in:2269
 msgid "release: %s"
 msgstr "release: %s"
 
-#: pkgmk.in:2164
+#: pkgmk.in:2272
 msgid "group:   %s"
 msgstr "group:   %s"
 
-#: pkgmk.in:2182
+#: pkgmk.in:2290
 msgid "Compression mode <%s> not supported."
 msgstr "Compression mode <%s> not supported."
 
-#: pkgmk.in:2210
+#: pkgmk.in:2318
 msgid "description: <%s>"
 msgstr "description: <%s>"
 
-#: pkgmk.in:2211
+#: pkgmk.in:2319
 msgid "url: <%s>"
 msgstr "url: <%s>"
 
-#: pkgmk.in:2212
+#: pkgmk.in:2320
 msgid "packager: <%s>"
 msgstr "packager: <%s>"
 
-#: pkgmk.in:2213
+#: pkgmk.in:2321
 msgid "maintainer: <%s>"
 msgstr "maintainer: <%s>"
 
-#: pkgmk.in:2221
+#: pkgmk.in:2329
 msgid "Md5sum updated."
 msgstr "Md5sum updated."
 
-#: pkgmk.in:2233
+#: pkgmk.in:2341
 msgid "Extracting sources of package <%s>"
 msgstr "Extracting sources of package <%s>"
 
-#: pkgmk.in:2243 pkgmk.in:2250
+#: pkgmk.in:2351 pkgmk.in:2358
 msgid "Package <%s> is not up to date."
 msgstr "Package <%s> is not up to date."
 
-#: pkgmk.in:2245 pkgmk.in:2252 pkgmk.in:2262 pkgmk.in:2274
+#: pkgmk.in:2353 pkgmk.in:2360 pkgmk.in:2370 pkgmk.in:2382
 msgid "Package <%s> is up to date."
 msgstr "Package <%s> is up to date."

--- a/scripts/po/fr_FR.UTF-8/LC_MESSAGES/pkgmk_empty.po
+++ b/scripts/po/fr_FR.UTF-8/LC_MESSAGES/pkgmk_empty.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cards\n"
 "Report-Msgid-Bugs-To: https://github.com/NuTyX/cards/issues\n"
-"POT-Creation-Date: 2016-03-01 13:16-0500\n"
-"PO-Revision-Date: 2016-03-01 13:16-0500\n"
+"POT-Creation-Date: 2016-03-01 16:18-0500\n"
+"PO-Revision-Date: 2016-03-01 16:18-0500\n"
 "Last-Translator: NuTyX Team <https://github.com/NuTyX/cards>\n"
 "Language-Team: LANGUAGE <https://github.com/NuTyX/cards>\n"
 "Language: fr\n"
@@ -17,442 +17,486 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: pkgmk.in:242
+#: pkgmk.in:243
 msgid "WARNING:"
 msgstr ""
 
-#: pkgmk.in:247 pkgmk.in:280 pkgmk.in:290
+#: pkgmk.in:248 pkgmk.in:281 pkgmk.in:291
 msgid "ERROR:"
 msgstr ""
 
-#: pkgmk.in:260 pkgmk.in:268 pkgmk.in:281
+#: pkgmk.in:261 pkgmk.in:269 pkgmk.in:282
 msgid "ABORTING....\\n"
 msgstr ""
 
-#: pkgmk.in:279
+#: pkgmk.in:280
 msgid "Building failed: <%s>"
 msgstr ""
 
-#: pkgmk.in:351
+#: pkgmk.in:313
+msgid "A failure occurred in %s()."
+msgstr ""
+
+#: pkgmk.in:314
+msgid "Aborting..."
+msgstr ""
+
+#: pkgmk.in:322
+msgid "Failed to source %s"
+msgstr ""
+
+#: pkgmk.in:404
 msgid "Directory <%s> does not exist."
 msgstr ""
 
-#: pkgmk.in:353
+#: pkgmk.in:406
 msgid "Directory <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:355
+#: pkgmk.in:408
 msgid "Directory <%s> is not readable."
 msgstr ""
 
-#: pkgmk.in:361
+#: pkgmk.in:414
 msgid "File <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:475
+#: pkgmk.in:528
 msgid "Removing source <%s>"
 msgstr ""
 
-#: pkgmk.in:543
+#: pkgmk.in:596
 msgid "Downloading file URL: <%s>"
 msgstr ""
 
-#: pkgmk.in:546
+#: pkgmk.in:599
 msgid "Command <%s> not found."
 msgstr ""
 
-#: pkgmk.in:577
+#: pkgmk.in:630
 msgid "Partial download found, trying to resume..."
 msgstr ""
 
-#: pkgmk.in:596
+#: pkgmk.in:649
 msgid "Partial download failed, restarting download..."
 msgstr ""
 
-#: pkgmk.in:625
+#: pkgmk.in:678
 msgid "Downloading git into: <%s>"
 msgstr ""
 
-#: pkgmk.in:631
+#: pkgmk.in:684
 msgid "Cloning git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:641
+#: pkgmk.in:694
 msgid "Updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:644
+#: pkgmk.in:697
 msgid "Failure while updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:668
+#: pkgmk.in:721
 msgid "Downloading svn into: <%s>"
 msgstr ""
 
-#: pkgmk.in:687
+#: pkgmk.in:740
 msgid "Cloning svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:694
+#: pkgmk.in:747
 msgid "Updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:698
+#: pkgmk.in:751
 msgid "Failure while updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:717
+#: pkgmk.in:770
 msgid "Downloading hg into: <%s>"
 msgstr ""
 
-#: pkgmk.in:723
+#: pkgmk.in:776
 msgid "Cloning hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:728
+#: pkgmk.in:781
 msgid "Updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:732
+#: pkgmk.in:785
 msgid "Failure while updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:755
+#: pkgmk.in:808
 msgid "Downloading bzr into: <%s>"
 msgstr ""
 
-#: pkgmk.in:758
+#: pkgmk.in:811
 msgid "Branching bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:763
+#: pkgmk.in:816
 msgid "Pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:767
+#: pkgmk.in:820
 msgid "Failure while pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:871
+#: pkgmk.in:924
 msgid "Extracting file with (%s): <%s>"
 msgstr ""
 
-#: pkgmk.in:908
+#: pkgmk.in:961
 msgid "Creating working copy of git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:962
+#: pkgmk.in:1015
 msgid "Creating working copy of svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:990
+#: pkgmk.in:1043
 msgid "Creating working copy of hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1044
+#: pkgmk.in:1097
 msgid "Creating working copy of bzr repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1072
+#: pkgmk.in:1127
+msgid "Package 'version' is not allowed to be empty."
+msgstr ""
+
+#: pkgmk.in:1130
+msgid "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace."
+msgstr ""
+
+#: pkgmk.in:1137
+msgid "Updating Pkgfile version variable..."
+msgstr ""
+
+#: pkgmk.in:1141
+msgid "setversion() generated an invalid version: %s"
+msgstr ""
+
+#: pkgmk.in:1146
+msgid "Failed to update 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1152
+msgid "Updated 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1153
+msgid "Full version is now: <%s>"
+msgstr ""
+
+#: pkgmk.in:1155
+msgid "<%s> is not writeable -- version will not be updated"
+msgstr ""
+
+#: pkgmk.in:1172
 msgid "Using (%s) to compress <%s>"
 msgstr ""
 
-#: pkgmk.in:1284
+#: pkgmk.in:1384
 msgid "Variable 'name' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1287
+#: pkgmk.in:1387
 msgid "Function 'build' not specified in <%s>"
 msgstr ""
 
-#: pkgmk.in:1291
+#: pkgmk.in:1391
 msgid "Variable 'name' contains following illegal characters: <%s>"
 msgstr ""
 
-#: pkgmk.in:1294
+#: pkgmk.in:1394
 msgid "Variable 'name' length higher then 50 characters."
 msgstr ""
 
-#: pkgmk.in:1297 pkgmk.in:2108 pkgmk.in:2111
+#: pkgmk.in:1397 pkgmk.in:2216 pkgmk.in:2219
 msgid "Variable 'version' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1300
+#: pkgmk.in:1402
 msgid "Variable 'release' not initiated or not found in<%s>"
 msgstr ""
 
-#: pkgmk.in:1304
+#: pkgmk.in:1406
 msgid "Variable 'release' contains following illegal characters:<%s>"
 msgstr ""
 
-#: pkgmk.in:1307
+#: pkgmk.in:1409
 msgid "Variable 'release' outside limit which is '99999999'."
 msgstr ""
 
-#: pkgmk.in:1310
+#: pkgmk.in:1412
 msgid "Variable 'description' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1314
+#: pkgmk.in:1416
 msgid "Variable 'description' length higher then 110 characters, please resize to 110 char ]"
 msgstr ""
 
-#: pkgmk.in:1315
+#: pkgmk.in:1417
 msgid "%s <== <%s> characters"
 msgstr ""
 
-#: pkgmk.in:1412
+#: pkgmk.in:1514
 msgid "Md5sum mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1420
+#: pkgmk.in:1522
 msgid "Md5sum not ok."
 msgstr ""
 
-#: pkgmk.in:1422 pkgmk.in:1684 pkgmk.in:1695 pkgmk.in:1701 pkgmk.in:1770
+#: pkgmk.in:1524 pkgmk.in:1792 pkgmk.in:1803 pkgmk.in:1809 pkgmk.in:1878
 msgid "Building <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1429
+#: pkgmk.in:1531
 msgid "Md5sum not found."
 msgstr ""
 
-#: pkgmk.in:1432
+#: pkgmk.in:1534
 msgid "Md5sum not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1440
+#: pkgmk.in:1542
 msgid "Md5sum ok."
 msgstr ""
 
-#: pkgmk.in:1477
+#: pkgmk.in:1579
 msgid "Unable to update footprint"
 msgstr ""
 
-#: pkgmk.in:1495 pkgmk.in:1497
+#: pkgmk.in:1597 pkgmk.in:1599
 msgid "Footprint mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1503
+#: pkgmk.in:1605
 msgid "Footprint not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1507
+#: pkgmk.in:1609
 msgid "Package <%s> was not found."
 msgstr ""
 
-#: pkgmk.in:1558
+#: pkgmk.in:1660
 msgid "Adding meta data to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1595 pkgmk.in:1606
+#: pkgmk.in:1697 pkgmk.in:1708
 msgid "Adding runtime deps to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1598 pkgmk.in:1609
+#: pkgmk.in:1700 pkgmk.in:1711
 msgid "Runtime dependency <%s> not found, cannot continue."
 msgstr ""
 
-#: pkgmk.in:1641
+#: pkgmk.in:1743
 msgid "<%s> should be removed."
 msgstr ""
 
-#: pkgmk.in:1643
+#: pkgmk.in:1745
 msgid "Remove the binaries first..."
 msgstr ""
 
-#: pkgmk.in:1651
+#: pkgmk.in:1753
 msgid "Packages should be built as root."
 msgstr ""
 
-#: pkgmk.in:1654
+#: pkgmk.in:1756
 msgid "Building package: <%s>"
 msgstr ""
 
-#: pkgmk.in:1737
+#: pkgmk.in:1845
 msgid "No files found in package <%s>"
 msgstr ""
 
-#: pkgmk.in:1742
+#: pkgmk.in:1850
 msgid "Footprint ignored."
 msgstr ""
 
-#: pkgmk.in:1753
+#: pkgmk.in:1861
 msgid "Package(s) not found(s)..."
 msgstr ""
 
-#: pkgmk.in:1778
+#: pkgmk.in:1886
 msgid "Package(s) not found(s) nothing to install..."
 msgstr ""
 
-#: pkgmk.in:1782
+#: pkgmk.in:1890
 msgid "Installing <%s>"
 msgstr ""
 
-#: pkgmk.in:1795
+#: pkgmk.in:1903
 msgid "Installing <%s> succeeded."
 msgstr ""
 
-#: pkgmk.in:1797
+#: pkgmk.in:1905
 msgid "Installing <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1812
+#: pkgmk.in:1920
 msgid "Entering directory  <%s>"
 msgstr ""
 
-#: pkgmk.in:1814
+#: pkgmk.in:1922
 msgid "Leaving directory <%s>"
 msgstr ""
 
-#: pkgmk.in:1825 pkgmk.in:1940
+#: pkgmk.in:1933 pkgmk.in:2048
 msgid "Removing <%s>"
 msgstr ""
 
-#: pkgmk.in:1830
+#: pkgmk.in:1938
 msgid "<%s> not found."
 msgstr ""
 
-#: pkgmk.in:1842
+#: pkgmk.in:1950
 msgid "Package(s) not found(s), unable to update footprint."
 msgstr ""
 
-#: pkgmk.in:1847
+#: pkgmk.in:1955
 msgid "Unable to update footprint. File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:1854
+#: pkgmk.in:1962
 msgid "Footprint updated for <%s>"
 msgstr ""
 
-#: pkgmk.in:1944
+#: pkgmk.in:2052
 msgid "Removing MD5SUM."
 msgstr ""
 
-#: pkgmk.in:2059 pkgmk.in:2078
+#: pkgmk.in:2167 pkgmk.in:2186
 msgid "File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:2064
+#: pkgmk.in:2172
 msgid "Command <pkginfo> NOT FOUND, footprint ignored."
 msgstr ""
 
-#: pkgmk.in:2118
+#: pkgmk.in:2226
 msgid "Configuration settings..."
 msgstr ""
 
-#: pkgmk.in:2119
+#: pkgmk.in:2227
 msgid "PKGMK_INSTALL:          %s"
 msgstr ""
 
-#: pkgmk.in:2120
+#: pkgmk.in:2228
 msgid "PKGMK_WORK_DIR:         %s"
 msgstr ""
 
-#: pkgmk.in:2121
+#: pkgmk.in:2229
 msgid "PKGMK_SOURCE_DIR:       %s"
 msgstr ""
 
-#: pkgmk.in:2125
+#: pkgmk.in:2233
 msgid "CLEAN IGNORED."
 msgstr ""
 
-#: pkgmk.in:2127
+#: pkgmk.in:2235
 msgid "PKGMK_KEEP_SOURCES:     %s"
 msgstr ""
 
-#: pkgmk.in:2128
+#: pkgmk.in:2236
 msgid "PKGMK_CLEAN:            %s"
 msgstr ""
 
-#: pkgmk.in:2133
+#: pkgmk.in:2241
 msgid "FOOTPRINT AND MD5SUM IGNORED."
 msgstr ""
 
-#: pkgmk.in:2136
+#: pkgmk.in:2244
 msgid "PKGMK_IGNORE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2138
+#: pkgmk.in:2246
 msgid "PKGMK_UPDATE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2140
+#: pkgmk.in:2248
 msgid "PKGMK_IGNORE_FOOTPRINT: %s"
 msgstr ""
 
-#: pkgmk.in:2141
+#: pkgmk.in:2249
 msgid "PKGMK_IGNORE_MD5SUM:    %s"
 msgstr ""
 
-#: pkgmk.in:2144
+#: pkgmk.in:2252
 msgid "<%s> file will be deleted."
 msgstr ""
 
-#: pkgmk.in:2147
+#: pkgmk.in:2255
 msgid "PKGMK_COMPRESS_PACKAGE: %s"
 msgstr ""
 
-#: pkgmk.in:2149
+#: pkgmk.in:2257
 msgid "PKGMK_COMPRESSION_MODE: %s"
 msgstr ""
 
-#: pkgmk.in:2151
+#: pkgmk.in:2259
 msgid "PKGMK_COMPRESSION_OPTS: %s"
 msgstr ""
 
-#: pkgmk.in:2155
+#: pkgmk.in:2263
 msgid "Package info..."
 msgstr ""
 
-#: pkgmk.in:2156
+#: pkgmk.in:2264
 msgid "name:    %s"
 msgstr ""
 
-#: pkgmk.in:2158
+#: pkgmk.in:2266
 msgid "version: %s"
 msgstr ""
 
-#: pkgmk.in:2161
+#: pkgmk.in:2269
 msgid "release: %s"
 msgstr ""
 
-#: pkgmk.in:2164
+#: pkgmk.in:2272
 msgid "group:   %s"
 msgstr ""
 
-#: pkgmk.in:2182
+#: pkgmk.in:2290
 msgid "Compression mode <%s> not supported."
 msgstr ""
 
-#: pkgmk.in:2210
+#: pkgmk.in:2318
 msgid "description: <%s>"
 msgstr ""
 
-#: pkgmk.in:2211
+#: pkgmk.in:2319
 msgid "url: <%s>"
 msgstr ""
 
-#: pkgmk.in:2212
+#: pkgmk.in:2320
 msgid "packager: <%s>"
 msgstr ""
 
-#: pkgmk.in:2213
+#: pkgmk.in:2321
 msgid "maintainer: <%s>"
 msgstr ""
 
-#: pkgmk.in:2221
+#: pkgmk.in:2329
 msgid "Md5sum updated."
 msgstr ""
 
-#: pkgmk.in:2233
+#: pkgmk.in:2341
 msgid "Extracting sources of package <%s>"
 msgstr ""
 
-#: pkgmk.in:2243 pkgmk.in:2250
+#: pkgmk.in:2351 pkgmk.in:2358
 msgid "Package <%s> is not up to date."
 msgstr ""
 
-#: pkgmk.in:2245 pkgmk.in:2252 pkgmk.in:2262 pkgmk.in:2274
+#: pkgmk.in:2353 pkgmk.in:2360 pkgmk.in:2370 pkgmk.in:2382
 msgid "Package <%s> is up to date."
 msgstr ""

--- a/scripts/po/pkgmk.pot
+++ b/scripts/po/pkgmk.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cards\n"
 "Report-Msgid-Bugs-To: https://github.com/NuTyX/cards/issues\n"
-"POT-Creation-Date: 2016-03-01 13:16-0500\n"
+"POT-Creation-Date: 2016-03-01 16:18-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <https://github.com/NuTyX/cards>\n"
@@ -17,442 +17,486 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: pkgmk.in:242
+#: pkgmk.in:243
 msgid "WARNING:"
 msgstr ""
 
-#: pkgmk.in:247 pkgmk.in:280 pkgmk.in:290
+#: pkgmk.in:248 pkgmk.in:281 pkgmk.in:291
 msgid "ERROR:"
 msgstr ""
 
-#: pkgmk.in:260 pkgmk.in:268 pkgmk.in:281
+#: pkgmk.in:261 pkgmk.in:269 pkgmk.in:282
 msgid "ABORTING....\\n"
 msgstr ""
 
-#: pkgmk.in:279
+#: pkgmk.in:280
 msgid "Building failed: <%s>"
 msgstr ""
 
-#: pkgmk.in:351
+#: pkgmk.in:313
+msgid "A failure occurred in %s()."
+msgstr ""
+
+#: pkgmk.in:314
+msgid "Aborting..."
+msgstr ""
+
+#: pkgmk.in:322
+msgid "Failed to source %s"
+msgstr ""
+
+#: pkgmk.in:404
 msgid "Directory <%s> does not exist."
 msgstr ""
 
-#: pkgmk.in:353
+#: pkgmk.in:406
 msgid "Directory <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:355
+#: pkgmk.in:408
 msgid "Directory <%s> is not readable."
 msgstr ""
 
-#: pkgmk.in:361
+#: pkgmk.in:414
 msgid "File <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:475
+#: pkgmk.in:528
 msgid "Removing source <%s>"
 msgstr ""
 
-#: pkgmk.in:543
+#: pkgmk.in:596
 msgid "Downloading file URL: <%s>"
 msgstr ""
 
-#: pkgmk.in:546
+#: pkgmk.in:599
 msgid "Command <%s> not found."
 msgstr ""
 
-#: pkgmk.in:577
+#: pkgmk.in:630
 msgid "Partial download found, trying to resume..."
 msgstr ""
 
-#: pkgmk.in:596
+#: pkgmk.in:649
 msgid "Partial download failed, restarting download..."
 msgstr ""
 
-#: pkgmk.in:625
+#: pkgmk.in:678
 msgid "Downloading git into: <%s>"
 msgstr ""
 
-#: pkgmk.in:631
+#: pkgmk.in:684
 msgid "Cloning git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:641
+#: pkgmk.in:694
 msgid "Updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:644
+#: pkgmk.in:697
 msgid "Failure while updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:668
+#: pkgmk.in:721
 msgid "Downloading svn into: <%s>"
 msgstr ""
 
-#: pkgmk.in:687
+#: pkgmk.in:740
 msgid "Cloning svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:694
+#: pkgmk.in:747
 msgid "Updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:698
+#: pkgmk.in:751
 msgid "Failure while updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:717
+#: pkgmk.in:770
 msgid "Downloading hg into: <%s>"
 msgstr ""
 
-#: pkgmk.in:723
+#: pkgmk.in:776
 msgid "Cloning hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:728
+#: pkgmk.in:781
 msgid "Updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:732
+#: pkgmk.in:785
 msgid "Failure while updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:755
+#: pkgmk.in:808
 msgid "Downloading bzr into: <%s>"
 msgstr ""
 
-#: pkgmk.in:758
+#: pkgmk.in:811
 msgid "Branching bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:763
+#: pkgmk.in:816
 msgid "Pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:767
+#: pkgmk.in:820
 msgid "Failure while pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:871
+#: pkgmk.in:924
 msgid "Extracting file with (%s): <%s>"
 msgstr ""
 
-#: pkgmk.in:908
+#: pkgmk.in:961
 msgid "Creating working copy of git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:962
+#: pkgmk.in:1015
 msgid "Creating working copy of svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:990
+#: pkgmk.in:1043
 msgid "Creating working copy of hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1044
+#: pkgmk.in:1097
 msgid "Creating working copy of bzr repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1072
+#: pkgmk.in:1127
+msgid "Package 'version' is not allowed to be empty."
+msgstr ""
+
+#: pkgmk.in:1130
+msgid "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace."
+msgstr ""
+
+#: pkgmk.in:1137
+msgid "Updating Pkgfile version variable..."
+msgstr ""
+
+#: pkgmk.in:1141
+msgid "setversion() generated an invalid version: %s"
+msgstr ""
+
+#: pkgmk.in:1146
+msgid "Failed to update 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1152
+msgid "Updated 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1153
+msgid "Full version is now: <%s>"
+msgstr ""
+
+#: pkgmk.in:1155
+msgid "<%s> is not writeable -- version will not be updated"
+msgstr ""
+
+#: pkgmk.in:1172
 msgid "Using (%s) to compress <%s>"
 msgstr ""
 
-#: pkgmk.in:1284
+#: pkgmk.in:1384
 msgid "Variable 'name' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1287
+#: pkgmk.in:1387
 msgid "Function 'build' not specified in <%s>"
 msgstr ""
 
-#: pkgmk.in:1291
+#: pkgmk.in:1391
 msgid "Variable 'name' contains following illegal characters: <%s>"
 msgstr ""
 
-#: pkgmk.in:1294
+#: pkgmk.in:1394
 msgid "Variable 'name' length higher then 50 characters."
 msgstr ""
 
-#: pkgmk.in:1297 pkgmk.in:2108 pkgmk.in:2111
+#: pkgmk.in:1397 pkgmk.in:2216 pkgmk.in:2219
 msgid "Variable 'version' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1300
+#: pkgmk.in:1402
 msgid "Variable 'release' not initiated or not found in<%s>"
 msgstr ""
 
-#: pkgmk.in:1304
+#: pkgmk.in:1406
 msgid "Variable 'release' contains following illegal characters:<%s>"
 msgstr ""
 
-#: pkgmk.in:1307
+#: pkgmk.in:1409
 msgid "Variable 'release' outside limit which is '99999999'."
 msgstr ""
 
-#: pkgmk.in:1310
+#: pkgmk.in:1412
 msgid "Variable 'description' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1314
+#: pkgmk.in:1416
 msgid "Variable 'description' length higher then 110 characters, please resize to 110 char ]"
 msgstr ""
 
-#: pkgmk.in:1315
+#: pkgmk.in:1417
 msgid "%s <== <%s> characters"
 msgstr ""
 
-#: pkgmk.in:1412
+#: pkgmk.in:1514
 msgid "Md5sum mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1420
+#: pkgmk.in:1522
 msgid "Md5sum not ok."
 msgstr ""
 
-#: pkgmk.in:1422 pkgmk.in:1684 pkgmk.in:1695 pkgmk.in:1701 pkgmk.in:1770
+#: pkgmk.in:1524 pkgmk.in:1792 pkgmk.in:1803 pkgmk.in:1809 pkgmk.in:1878
 msgid "Building <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1429
+#: pkgmk.in:1531
 msgid "Md5sum not found."
 msgstr ""
 
-#: pkgmk.in:1432
+#: pkgmk.in:1534
 msgid "Md5sum not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1440
+#: pkgmk.in:1542
 msgid "Md5sum ok."
 msgstr ""
 
-#: pkgmk.in:1477
+#: pkgmk.in:1579
 msgid "Unable to update footprint"
 msgstr ""
 
-#: pkgmk.in:1495 pkgmk.in:1497
+#: pkgmk.in:1597 pkgmk.in:1599
 msgid "Footprint mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1503
+#: pkgmk.in:1605
 msgid "Footprint not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1507
+#: pkgmk.in:1609
 msgid "Package <%s> was not found."
 msgstr ""
 
-#: pkgmk.in:1558
+#: pkgmk.in:1660
 msgid "Adding meta data to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1595 pkgmk.in:1606
+#: pkgmk.in:1697 pkgmk.in:1708
 msgid "Adding runtime deps to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1598 pkgmk.in:1609
+#: pkgmk.in:1700 pkgmk.in:1711
 msgid "Runtime dependency <%s> not found, cannot continue."
 msgstr ""
 
-#: pkgmk.in:1641
+#: pkgmk.in:1743
 msgid "<%s> should be removed."
 msgstr ""
 
-#: pkgmk.in:1643
+#: pkgmk.in:1745
 msgid "Remove the binaries first..."
 msgstr ""
 
-#: pkgmk.in:1651
+#: pkgmk.in:1753
 msgid "Packages should be built as root."
 msgstr ""
 
-#: pkgmk.in:1654
+#: pkgmk.in:1756
 msgid "Building package: <%s>"
 msgstr ""
 
-#: pkgmk.in:1737
+#: pkgmk.in:1845
 msgid "No files found in package <%s>"
 msgstr ""
 
-#: pkgmk.in:1742
+#: pkgmk.in:1850
 msgid "Footprint ignored."
 msgstr ""
 
-#: pkgmk.in:1753
+#: pkgmk.in:1861
 msgid "Package(s) not found(s)..."
 msgstr ""
 
-#: pkgmk.in:1778
+#: pkgmk.in:1886
 msgid "Package(s) not found(s) nothing to install..."
 msgstr ""
 
-#: pkgmk.in:1782
+#: pkgmk.in:1890
 msgid "Installing <%s>"
 msgstr ""
 
-#: pkgmk.in:1795
+#: pkgmk.in:1903
 msgid "Installing <%s> succeeded."
 msgstr ""
 
-#: pkgmk.in:1797
+#: pkgmk.in:1905
 msgid "Installing <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1812
+#: pkgmk.in:1920
 msgid "Entering directory  <%s>"
 msgstr ""
 
-#: pkgmk.in:1814
+#: pkgmk.in:1922
 msgid "Leaving directory <%s>"
 msgstr ""
 
-#: pkgmk.in:1825 pkgmk.in:1940
+#: pkgmk.in:1933 pkgmk.in:2048
 msgid "Removing <%s>"
 msgstr ""
 
-#: pkgmk.in:1830
+#: pkgmk.in:1938
 msgid "<%s> not found."
 msgstr ""
 
-#: pkgmk.in:1842
+#: pkgmk.in:1950
 msgid "Package(s) not found(s), unable to update footprint."
 msgstr ""
 
-#: pkgmk.in:1847
+#: pkgmk.in:1955
 msgid "Unable to update footprint. File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:1854
+#: pkgmk.in:1962
 msgid "Footprint updated for <%s>"
 msgstr ""
 
-#: pkgmk.in:1944
+#: pkgmk.in:2052
 msgid "Removing MD5SUM."
 msgstr ""
 
-#: pkgmk.in:2059 pkgmk.in:2078
+#: pkgmk.in:2167 pkgmk.in:2186
 msgid "File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:2064
+#: pkgmk.in:2172
 msgid "Command <pkginfo> NOT FOUND, footprint ignored."
 msgstr ""
 
-#: pkgmk.in:2118
+#: pkgmk.in:2226
 msgid "Configuration settings..."
 msgstr ""
 
-#: pkgmk.in:2119
+#: pkgmk.in:2227
 msgid "PKGMK_INSTALL:          %s"
 msgstr ""
 
-#: pkgmk.in:2120
+#: pkgmk.in:2228
 msgid "PKGMK_WORK_DIR:         %s"
 msgstr ""
 
-#: pkgmk.in:2121
+#: pkgmk.in:2229
 msgid "PKGMK_SOURCE_DIR:       %s"
 msgstr ""
 
-#: pkgmk.in:2125
+#: pkgmk.in:2233
 msgid "CLEAN IGNORED."
 msgstr ""
 
-#: pkgmk.in:2127
+#: pkgmk.in:2235
 msgid "PKGMK_KEEP_SOURCES:     %s"
 msgstr ""
 
-#: pkgmk.in:2128
+#: pkgmk.in:2236
 msgid "PKGMK_CLEAN:            %s"
 msgstr ""
 
-#: pkgmk.in:2133
+#: pkgmk.in:2241
 msgid "FOOTPRINT AND MD5SUM IGNORED."
 msgstr ""
 
-#: pkgmk.in:2136
+#: pkgmk.in:2244
 msgid "PKGMK_IGNORE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2138
+#: pkgmk.in:2246
 msgid "PKGMK_UPDATE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2140
+#: pkgmk.in:2248
 msgid "PKGMK_IGNORE_FOOTPRINT: %s"
 msgstr ""
 
-#: pkgmk.in:2141
+#: pkgmk.in:2249
 msgid "PKGMK_IGNORE_MD5SUM:    %s"
 msgstr ""
 
-#: pkgmk.in:2144
+#: pkgmk.in:2252
 msgid "<%s> file will be deleted."
 msgstr ""
 
-#: pkgmk.in:2147
+#: pkgmk.in:2255
 msgid "PKGMK_COMPRESS_PACKAGE: %s"
 msgstr ""
 
-#: pkgmk.in:2149
+#: pkgmk.in:2257
 msgid "PKGMK_COMPRESSION_MODE: %s"
 msgstr ""
 
-#: pkgmk.in:2151
+#: pkgmk.in:2259
 msgid "PKGMK_COMPRESSION_OPTS: %s"
 msgstr ""
 
-#: pkgmk.in:2155
+#: pkgmk.in:2263
 msgid "Package info..."
 msgstr ""
 
-#: pkgmk.in:2156
+#: pkgmk.in:2264
 msgid "name:    %s"
 msgstr ""
 
-#: pkgmk.in:2158
+#: pkgmk.in:2266
 msgid "version: %s"
 msgstr ""
 
-#: pkgmk.in:2161
+#: pkgmk.in:2269
 msgid "release: %s"
 msgstr ""
 
-#: pkgmk.in:2164
+#: pkgmk.in:2272
 msgid "group:   %s"
 msgstr ""
 
-#: pkgmk.in:2182
+#: pkgmk.in:2290
 msgid "Compression mode <%s> not supported."
 msgstr ""
 
-#: pkgmk.in:2210
+#: pkgmk.in:2318
 msgid "description: <%s>"
 msgstr ""
 
-#: pkgmk.in:2211
+#: pkgmk.in:2319
 msgid "url: <%s>"
 msgstr ""
 
-#: pkgmk.in:2212
+#: pkgmk.in:2320
 msgid "packager: <%s>"
 msgstr ""
 
-#: pkgmk.in:2213
+#: pkgmk.in:2321
 msgid "maintainer: <%s>"
 msgstr ""
 
-#: pkgmk.in:2221
+#: pkgmk.in:2329
 msgid "Md5sum updated."
 msgstr ""
 
-#: pkgmk.in:2233
+#: pkgmk.in:2341
 msgid "Extracting sources of package <%s>"
 msgstr ""
 
-#: pkgmk.in:2243 pkgmk.in:2250
+#: pkgmk.in:2351 pkgmk.in:2358
 msgid "Package <%s> is not up to date."
 msgstr ""
 
-#: pkgmk.in:2245 pkgmk.in:2252 pkgmk.in:2262 pkgmk.in:2274
+#: pkgmk.in:2353 pkgmk.in:2360 pkgmk.in:2370 pkgmk.in:2382
 msgid "Package <%s> is up to date."
 msgstr ""

--- a/scripts/po/pt_BR.UTF-8/LC_MESSAGES/pkgmk_empty.po
+++ b/scripts/po/pt_BR.UTF-8/LC_MESSAGES/pkgmk_empty.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cards\n"
 "Report-Msgid-Bugs-To: https://github.com/NuTyX/cards/issues\n"
-"POT-Creation-Date: 2016-03-01 13:16-0500\n"
-"PO-Revision-Date: 2016-03-01 13:16-0500\n"
+"POT-Creation-Date: 2016-03-01 16:18-0500\n"
+"PO-Revision-Date: 2016-03-01 16:18-0500\n"
 "Last-Translator: NuTyX Team <https://github.com/NuTyX/cards>\n"
 "Language-Team: LANGUAGE <https://github.com/NuTyX/cards>\n"
 "Language: pt_BR\n"
@@ -17,442 +17,486 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: pkgmk.in:242
+#: pkgmk.in:243
 msgid "WARNING:"
 msgstr ""
 
-#: pkgmk.in:247 pkgmk.in:280 pkgmk.in:290
+#: pkgmk.in:248 pkgmk.in:281 pkgmk.in:291
 msgid "ERROR:"
 msgstr ""
 
-#: pkgmk.in:260 pkgmk.in:268 pkgmk.in:281
+#: pkgmk.in:261 pkgmk.in:269 pkgmk.in:282
 msgid "ABORTING....\\n"
 msgstr ""
 
-#: pkgmk.in:279
+#: pkgmk.in:280
 msgid "Building failed: <%s>"
 msgstr ""
 
-#: pkgmk.in:351
+#: pkgmk.in:313
+msgid "A failure occurred in %s()."
+msgstr ""
+
+#: pkgmk.in:314
+msgid "Aborting..."
+msgstr ""
+
+#: pkgmk.in:322
+msgid "Failed to source %s"
+msgstr ""
+
+#: pkgmk.in:404
 msgid "Directory <%s> does not exist."
 msgstr ""
 
-#: pkgmk.in:353
+#: pkgmk.in:406
 msgid "Directory <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:355
+#: pkgmk.in:408
 msgid "Directory <%s> is not readable."
 msgstr ""
 
-#: pkgmk.in:361
+#: pkgmk.in:414
 msgid "File <%s> is not writable."
 msgstr ""
 
-#: pkgmk.in:475
+#: pkgmk.in:528
 msgid "Removing source <%s>"
 msgstr ""
 
-#: pkgmk.in:543
+#: pkgmk.in:596
 msgid "Downloading file URL: <%s>"
 msgstr ""
 
-#: pkgmk.in:546
+#: pkgmk.in:599
 msgid "Command <%s> not found."
 msgstr ""
 
-#: pkgmk.in:577
+#: pkgmk.in:630
 msgid "Partial download found, trying to resume..."
 msgstr ""
 
-#: pkgmk.in:596
+#: pkgmk.in:649
 msgid "Partial download failed, restarting download..."
 msgstr ""
 
-#: pkgmk.in:625
+#: pkgmk.in:678
 msgid "Downloading git into: <%s>"
 msgstr ""
 
-#: pkgmk.in:631
+#: pkgmk.in:684
 msgid "Cloning git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:641
+#: pkgmk.in:694
 msgid "Updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:644
+#: pkgmk.in:697
 msgid "Failure while updating git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:668
+#: pkgmk.in:721
 msgid "Downloading svn into: <%s>"
 msgstr ""
 
-#: pkgmk.in:687
+#: pkgmk.in:740
 msgid "Cloning svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:694
+#: pkgmk.in:747
 msgid "Updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:698
+#: pkgmk.in:751
 msgid "Failure while updating svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:717
+#: pkgmk.in:770
 msgid "Downloading hg into: <%s>"
 msgstr ""
 
-#: pkgmk.in:723
+#: pkgmk.in:776
 msgid "Cloning hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:728
+#: pkgmk.in:781
 msgid "Updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:732
+#: pkgmk.in:785
 msgid "Failure while updating hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:755
+#: pkgmk.in:808
 msgid "Downloading bzr into: <%s>"
 msgstr ""
 
-#: pkgmk.in:758
+#: pkgmk.in:811
 msgid "Branching bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:763
+#: pkgmk.in:816
 msgid "Pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:767
+#: pkgmk.in:820
 msgid "Failure while pulling bzr displaylocation <%s>"
 msgstr ""
 
-#: pkgmk.in:871
+#: pkgmk.in:924
 msgid "Extracting file with (%s): <%s>"
 msgstr ""
 
-#: pkgmk.in:908
+#: pkgmk.in:961
 msgid "Creating working copy of git repo <%s>"
 msgstr ""
 
-#: pkgmk.in:962
+#: pkgmk.in:1015
 msgid "Creating working copy of svn repo <%s>"
 msgstr ""
 
-#: pkgmk.in:990
+#: pkgmk.in:1043
 msgid "Creating working copy of hg repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1044
+#: pkgmk.in:1097
 msgid "Creating working copy of bzr repo <%s>"
 msgstr ""
 
-#: pkgmk.in:1072
+#: pkgmk.in:1127
+msgid "Package 'version' is not allowed to be empty."
+msgstr ""
+
+#: pkgmk.in:1130
+msgid "Package 'version': <%s> is not allowed to contain pipe, colons, hyphens or whitespace."
+msgstr ""
+
+#: pkgmk.in:1137
+msgid "Updating Pkgfile version variable..."
+msgstr ""
+
+#: pkgmk.in:1141
+msgid "setversion() generated an invalid version: %s"
+msgstr ""
+
+#: pkgmk.in:1146
+msgid "Failed to update 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1152
+msgid "Updated 'Pkgfile version' from: <%s> to <%s>"
+msgstr ""
+
+#: pkgmk.in:1153
+msgid "Full version is now: <%s>"
+msgstr ""
+
+#: pkgmk.in:1155
+msgid "<%s> is not writeable -- version will not be updated"
+msgstr ""
+
+#: pkgmk.in:1172
 msgid "Using (%s) to compress <%s>"
 msgstr ""
 
-#: pkgmk.in:1284
+#: pkgmk.in:1384
 msgid "Variable 'name' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1287
+#: pkgmk.in:1387
 msgid "Function 'build' not specified in <%s>"
 msgstr ""
 
-#: pkgmk.in:1291
+#: pkgmk.in:1391
 msgid "Variable 'name' contains following illegal characters: <%s>"
 msgstr ""
 
-#: pkgmk.in:1294
+#: pkgmk.in:1394
 msgid "Variable 'name' length higher then 50 characters."
 msgstr ""
 
-#: pkgmk.in:1297 pkgmk.in:2108 pkgmk.in:2111
+#: pkgmk.in:1397 pkgmk.in:2216 pkgmk.in:2219
 msgid "Variable 'version' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1300
+#: pkgmk.in:1402
 msgid "Variable 'release' not initiated or not found in<%s>"
 msgstr ""
 
-#: pkgmk.in:1304
+#: pkgmk.in:1406
 msgid "Variable 'release' contains following illegal characters:<%s>"
 msgstr ""
 
-#: pkgmk.in:1307
+#: pkgmk.in:1409
 msgid "Variable 'release' outside limit which is '99999999'."
 msgstr ""
 
-#: pkgmk.in:1310
+#: pkgmk.in:1412
 msgid "Variable 'description' not initiated or not found in <%s>"
 msgstr ""
 
-#: pkgmk.in:1314
+#: pkgmk.in:1416
 msgid "Variable 'description' length higher then 110 characters, please resize to 110 char ]"
 msgstr ""
 
-#: pkgmk.in:1315
+#: pkgmk.in:1417
 msgid "%s <== <%s> characters"
 msgstr ""
 
-#: pkgmk.in:1412
+#: pkgmk.in:1514
 msgid "Md5sum mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1420
+#: pkgmk.in:1522
 msgid "Md5sum not ok."
 msgstr ""
 
-#: pkgmk.in:1422 pkgmk.in:1684 pkgmk.in:1695 pkgmk.in:1701 pkgmk.in:1770
+#: pkgmk.in:1524 pkgmk.in:1792 pkgmk.in:1803 pkgmk.in:1809 pkgmk.in:1878
 msgid "Building <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1429
+#: pkgmk.in:1531
 msgid "Md5sum not found."
 msgstr ""
 
-#: pkgmk.in:1432
+#: pkgmk.in:1534
 msgid "Md5sum not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1440
+#: pkgmk.in:1542
 msgid "Md5sum ok."
 msgstr ""
 
-#: pkgmk.in:1477
+#: pkgmk.in:1579
 msgid "Unable to update footprint"
 msgstr ""
 
-#: pkgmk.in:1495 pkgmk.in:1497
+#: pkgmk.in:1597 pkgmk.in:1599
 msgid "Footprint mismatch found:"
 msgstr ""
 
-#: pkgmk.in:1503
+#: pkgmk.in:1605
 msgid "Footprint not found, creating new."
 msgstr ""
 
-#: pkgmk.in:1507
+#: pkgmk.in:1609
 msgid "Package <%s> was not found."
 msgstr ""
 
-#: pkgmk.in:1558
+#: pkgmk.in:1660
 msgid "Adding meta data to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1595 pkgmk.in:1606
+#: pkgmk.in:1697 pkgmk.in:1708
 msgid "Adding runtime deps to Archive <%s>"
 msgstr ""
 
-#: pkgmk.in:1598 pkgmk.in:1609
+#: pkgmk.in:1700 pkgmk.in:1711
 msgid "Runtime dependency <%s> not found, cannot continue."
 msgstr ""
 
-#: pkgmk.in:1641
+#: pkgmk.in:1743
 msgid "<%s> should be removed."
 msgstr ""
 
-#: pkgmk.in:1643
+#: pkgmk.in:1745
 msgid "Remove the binaries first..."
 msgstr ""
 
-#: pkgmk.in:1651
+#: pkgmk.in:1753
 msgid "Packages should be built as root."
 msgstr ""
 
-#: pkgmk.in:1654
+#: pkgmk.in:1756
 msgid "Building package: <%s>"
 msgstr ""
 
-#: pkgmk.in:1737
+#: pkgmk.in:1845
 msgid "No files found in package <%s>"
 msgstr ""
 
-#: pkgmk.in:1742
+#: pkgmk.in:1850
 msgid "Footprint ignored."
 msgstr ""
 
-#: pkgmk.in:1753
+#: pkgmk.in:1861
 msgid "Package(s) not found(s)..."
 msgstr ""
 
-#: pkgmk.in:1778
+#: pkgmk.in:1886
 msgid "Package(s) not found(s) nothing to install..."
 msgstr ""
 
-#: pkgmk.in:1782
+#: pkgmk.in:1890
 msgid "Installing <%s>"
 msgstr ""
 
-#: pkgmk.in:1795
+#: pkgmk.in:1903
 msgid "Installing <%s> succeeded."
 msgstr ""
 
-#: pkgmk.in:1797
+#: pkgmk.in:1905
 msgid "Installing <%s> failed."
 msgstr ""
 
-#: pkgmk.in:1812
+#: pkgmk.in:1920
 msgid "Entering directory  <%s>"
 msgstr ""
 
-#: pkgmk.in:1814
+#: pkgmk.in:1922
 msgid "Leaving directory <%s>"
 msgstr ""
 
-#: pkgmk.in:1825 pkgmk.in:1940
+#: pkgmk.in:1933 pkgmk.in:2048
 msgid "Removing <%s>"
 msgstr ""
 
-#: pkgmk.in:1830
+#: pkgmk.in:1938
 msgid "<%s> not found."
 msgstr ""
 
-#: pkgmk.in:1842
+#: pkgmk.in:1950
 msgid "Package(s) not found(s), unable to update footprint."
 msgstr ""
 
-#: pkgmk.in:1847
+#: pkgmk.in:1955
 msgid "Unable to update footprint. File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:1854
+#: pkgmk.in:1962
 msgid "Footprint updated for <%s>"
 msgstr ""
 
-#: pkgmk.in:1944
+#: pkgmk.in:2052
 msgid "Removing MD5SUM."
 msgstr ""
 
-#: pkgmk.in:2059 pkgmk.in:2078
+#: pkgmk.in:2167 pkgmk.in:2186
 msgid "File <%s> not found."
 msgstr ""
 
-#: pkgmk.in:2064
+#: pkgmk.in:2172
 msgid "Command <pkginfo> NOT FOUND, footprint ignored."
 msgstr ""
 
-#: pkgmk.in:2118
+#: pkgmk.in:2226
 msgid "Configuration settings..."
 msgstr ""
 
-#: pkgmk.in:2119
+#: pkgmk.in:2227
 msgid "PKGMK_INSTALL:          %s"
 msgstr ""
 
-#: pkgmk.in:2120
+#: pkgmk.in:2228
 msgid "PKGMK_WORK_DIR:         %s"
 msgstr ""
 
-#: pkgmk.in:2121
+#: pkgmk.in:2229
 msgid "PKGMK_SOURCE_DIR:       %s"
 msgstr ""
 
-#: pkgmk.in:2125
+#: pkgmk.in:2233
 msgid "CLEAN IGNORED."
 msgstr ""
 
-#: pkgmk.in:2127
+#: pkgmk.in:2235
 msgid "PKGMK_KEEP_SOURCES:     %s"
 msgstr ""
 
-#: pkgmk.in:2128
+#: pkgmk.in:2236
 msgid "PKGMK_CLEAN:            %s"
 msgstr ""
 
-#: pkgmk.in:2133
+#: pkgmk.in:2241
 msgid "FOOTPRINT AND MD5SUM IGNORED."
 msgstr ""
 
-#: pkgmk.in:2136
+#: pkgmk.in:2244
 msgid "PKGMK_IGNORE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2138
+#: pkgmk.in:2246
 msgid "PKGMK_UPDATE_REPO:      %s"
 msgstr ""
 
-#: pkgmk.in:2140
+#: pkgmk.in:2248
 msgid "PKGMK_IGNORE_FOOTPRINT: %s"
 msgstr ""
 
-#: pkgmk.in:2141
+#: pkgmk.in:2249
 msgid "PKGMK_IGNORE_MD5SUM:    %s"
 msgstr ""
 
-#: pkgmk.in:2144
+#: pkgmk.in:2252
 msgid "<%s> file will be deleted."
 msgstr ""
 
-#: pkgmk.in:2147
+#: pkgmk.in:2255
 msgid "PKGMK_COMPRESS_PACKAGE: %s"
 msgstr ""
 
-#: pkgmk.in:2149
+#: pkgmk.in:2257
 msgid "PKGMK_COMPRESSION_MODE: %s"
 msgstr ""
 
-#: pkgmk.in:2151
+#: pkgmk.in:2259
 msgid "PKGMK_COMPRESSION_OPTS: %s"
 msgstr ""
 
-#: pkgmk.in:2155
+#: pkgmk.in:2263
 msgid "Package info..."
 msgstr ""
 
-#: pkgmk.in:2156
+#: pkgmk.in:2264
 msgid "name:    %s"
 msgstr ""
 
-#: pkgmk.in:2158
+#: pkgmk.in:2266
 msgid "version: %s"
 msgstr ""
 
-#: pkgmk.in:2161
+#: pkgmk.in:2269
 msgid "release: %s"
 msgstr ""
 
-#: pkgmk.in:2164
+#: pkgmk.in:2272
 msgid "group:   %s"
 msgstr ""
 
-#: pkgmk.in:2182
+#: pkgmk.in:2290
 msgid "Compression mode <%s> not supported."
 msgstr ""
 
-#: pkgmk.in:2210
+#: pkgmk.in:2318
 msgid "description: <%s>"
 msgstr ""
 
-#: pkgmk.in:2211
+#: pkgmk.in:2319
 msgid "url: <%s>"
 msgstr ""
 
-#: pkgmk.in:2212
+#: pkgmk.in:2320
 msgid "packager: <%s>"
 msgstr ""
 
-#: pkgmk.in:2213
+#: pkgmk.in:2321
 msgid "maintainer: <%s>"
 msgstr ""
 
-#: pkgmk.in:2221
+#: pkgmk.in:2329
 msgid "Md5sum updated."
 msgstr ""
 
-#: pkgmk.in:2233
+#: pkgmk.in:2341
 msgid "Extracting sources of package <%s>"
 msgstr ""
 
-#: pkgmk.in:2243 pkgmk.in:2250
+#: pkgmk.in:2351 pkgmk.in:2358
 msgid "Package <%s> is not up to date."
 msgstr ""
 
-#: pkgmk.in:2245 pkgmk.in:2252 pkgmk.in:2262 pkgmk.in:2274
+#: pkgmk.in:2353 pkgmk.in:2360 pkgmk.in:2370 pkgmk.in:2382
 msgid "Package <%s> is up to date."
 msgstr ""


### PR DESCRIPTION
Auto-Update Pkgfile version: this is a similar feature what Arch Linux has for PKGBUILD files.

If the Pkgfile has a function: `setversion()   Example


```
setversion() {
    cd $SRC/$name
    cur_prefix='v'
    if git_version=$( git describe --long --tags 2>/dev/null ); then
        local _tag_stripped="$(git describe --abbrev=0 --tags | sed 's/^'${cur_prefix}'//;s/-/./g')"
        local _rev="$(($(git rev-list --count HEAD)-$(git rev-list --count $(git describe --abbrev=0 --tags))))"
        printf "${_tag_stripped}.r${_rev}.%s" "$(git rev-parse --short HEAD)"
    else
        printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
    fi
}
```