### PR TITLE
prt-get copyright notice: 20002->2002

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Read the COPYING file for the complete license.
 #### Licenses for incorporated software
 
 * `pkgutils`: Copyright (c) 2000-2005 Per Liden and Copyright (c) 2006-2013 CRUX team <http://crux.nu> [GPL2/later]
-* `prt-get`:  Copyright (c) 20002, 2004, 2005 Johannes Winkelmann (jw@tks6.net) [GPL2/later]
+* `prt-get`:  Copyright (c) 2002, 2004, 2005 Johannes Winkelmann (jw@tks6.net) [GPL2/later]
 * `pacman`:   Copyright (c) 2006-2016 Pacman Development Team <pacman-dev@archlinux.org> [GPL2/later]
 * `pacman`:   Copyright (c) 2002-2006 by Judd Vinet <jvinet@zeroflux.org> [GPL2/later]
 


### PR DESCRIPTION
Hi,

The year 20002 hasn't come yet so I'm pretty sure that wasn't the year intended in the copyright notice, hence changing it to 2002. 

Thanks for your time,
Brenton